### PR TITLE
New function: vdbgen()

### DIFF
--- a/.test_env
+++ b/.test_env
@@ -14,6 +14,14 @@ echo "sd=sd${i},lun=/dev/${DN},openflags=o_direct"
 done
 }
 
+vdbgen()
+{
+# HELP : Generate vdbench profiles.
+VDBTEMPLATES=/opt/beetle/opt/vdbench_profiles
+vdblist > /tmp/vdblist.out
+for file in $(ls $VDBTEMPLATES | xargs -n1); do sed -e'/sdXX/r/tmp/vdblist.out' $VDBTEMPLATES/$file > /tmp/$file; done
+}
+
 iochk() 
 {
 # HELP : Generate IOSTAT output for devices with some activity.


### PR DESCRIPTION
I created a new function called vdbgen() that takes the output of vdblist() and generates ready-to-run vdbench profiles based on the templates in /opt/beetle/opt/vdbench_profiles.  It places the newly created profiles in /tmp.